### PR TITLE
Fixed code reviewer requests

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -135,7 +135,7 @@ module Enumerable
     else
       array.drop(1).my_each { |next_element| result = result.send(arg1, next_element) } if only_one_arg
 
-      array.drop(1).my_each { |next_element| result = result.send(arg2, next_element) } if both_args
+      array.my_each { |next_element| result = result.send(arg2, next_element) } if both_args
 
     end
     result
@@ -151,7 +151,5 @@ end
 my_proc = proc { |num| num > 6 }
 p [2, 54, 6, 7].my_map(my_proc) { |num| num < 10 }
 
-p (1..5).my_inject(20, :*)
-p [1, 2, 3, 4, 5].my_inject(20, :*)
-p (1..5).inject(20, :*)
-p [1, 2, 3, 4, 5].inject(20, :*)
+p 5.times.my_inject(20, :*)
+p 5.times.inject(20, :*)

--- a/main.rb
+++ b/main.rb
@@ -102,13 +102,14 @@ module Enumerable
     count
   end
 
-  def my_map(&_change_proc)
+  def my_map(proc = nil)
     return to_enum(:map) unless block_given?
 
     array = to_a
     output_array = []
 
-    array.my_each { |element| output_array << yield(element) }
+    array.my_each { |element| output_array << proc.call(element) } if proc
+    array.my_each { |element| output_array << yield(element) } unless proc
 
     output_array
   end
@@ -121,6 +122,8 @@ module Enumerable
     both_args = arg1 && arg2
     only_one_arg = arg1 && !arg2
     no_arg = !arg1
+
+    raise LocalJumpError if !block_given? && no_arg
 
     result = both_args || (only_one_arg && block_given?) ? arg1 : array.first
 
@@ -145,14 +148,10 @@ def multiply_els(array)
   array.my_inject(:*)
 end
 
-p(%w[Marc Luc Jean].my_all? { |text| text.size >= 3 }) # => true
-p(%w[Marc Luc Jean].my_all? { |text| text.size >= 4 }) # => false
-p [2, 1, 6, 7, 4, 8, 10].my_all?(3) # => false
-p %w[Marc Luc Jean].my_all?('Jean') # => false
-p %w[Marc Luc Jean].my_all?(/a/) # => false
-p [1, 5i, 5.67].my_all?(Numeric) # => true
-p [2, 1, 6, 7, 4, 8, 10].my_all?(Integer) # => true
-p [nil, true, 99].my_all? # => false
-p [nil, false].my_all? # => false
-p [nil, nil, nil].my_all? # => false
-p [].my_all? # => true
+my_proc = proc { |num| num > 6 }
+p [2, 54, 6, 7].my_map(my_proc) { |num| num < 10 }
+
+p (1..5).my_inject(20, :*)
+p [1, 2, 3, 4, 5].my_inject(20, :*)
+p (1..5).inject(20, :*)
+p [1, 2, 3, 4, 5].inject(20, :*)


### PR DESCRIPTION
We closed our first pull request because it was not following the correct flow, the changes required by the TSE were the following:

To fix:

- [x] IMPORTANT! - Please close this PR and open a new one from the feature branch to the development branch. Also, you are not supposed to commit directly to the development branch.
 
- [x] my_map should execute only the proc when both a block and a proc are given. Fails in this scenario array.my_map(my_proc) { |num| num < 10 }.

- [x] my_inject failed to raise a "LocalJumpError" when no block or argument is given.

- [x] Also my_inject returned the wrong result when the range is given and a symbol is specified with an initial value such as this range.my_inject(2, :*).


We fixed all of them as per below tests:
![fixes](https://user-images.githubusercontent.com/19146884/89789289-0f984180-db29-11ea-87e8-05ddf7dd0421.png)
